### PR TITLE
Update TypeScript SDK version to v0.5.0

### DIFF
--- a/spin/apps/01-getting-started/hello-typescript/package-lock.json
+++ b/spin/apps/01-getting-started/hello-typescript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@fermyon/spin-sdk": "^0.4.1",
+        "@fermyon/spin-sdk": "^0.5.0",
         "ts-loader": "^9.4.1",
         "typescript": "^4.8.4",
         "webpack": "^5.74.0",
@@ -26,10 +26,17 @@
       }
     },
     "node_modules/@fermyon/spin-sdk": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@fermyon/spin-sdk/-/spin-sdk-0.4.1.tgz",
-      "integrity": "sha512-EeiHN9p++1y0U2JwBYdU0k0h5qTv6wHxL0F8mTia/DbBsYwUziCHr7VWAGP5+DVmmvLuzC+mEhs9AM+ajVsQJQ==",
-      "dev": true
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@fermyon/spin-sdk/-/spin-sdk-0.5.0.tgz",
+      "integrity": "sha512-LMDEU+Zb+Sl0v/ZlTwKTpZ355wCanqs2jKIwbdnl89Rspllo/GhW/QzBgqRuMP1RidIdBXSorxhhufnmMnxQOQ==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "npm:Buffer@^0.0.0",
+        "Buffer": "^0.0.0",
+        "fast-text-encoding": "^1.0.6",
+        "itty-router": "^3.0.12",
+        "typedarray-to-buffer": "^4.0.0"
+      }
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.2",
@@ -422,6 +429,15 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/Buffer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/Buffer/-/Buffer-0.0.0.tgz",
+      "integrity": "sha512-+zdncl8lI5TCkARStn9F1BwcuJYofYmD0oEHe5FNfCvGfeDJwf6+dSikCdQN6BMXXmHMhNNUagBN367WST1AIQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.2.0"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -637,6 +653,12 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
+    "node_modules/fast-text-encoding": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
+      "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==",
+      "dev": true
+    },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -785,6 +807,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/itty-router": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-3.0.12.tgz",
+      "integrity": "sha512-s98XTPhle6GGbaFf0kYrOD3Q8gyhnqvOqkwYijC3AmkceNKqWUp13YHg6dWmqmVv4pP7l7c94XI92I0EXVGO0w==",
+      "dev": true
     },
     "node_modules/jest-worker": {
       "version": "27.5.1",
@@ -1309,6 +1337,26 @@
         "webpack": "^5.0.0"
       }
     },
+    "node_modules/typedarray-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-6dOYeZfS3O9RtRD1caom0sMxgK59b27+IwoNy8RDPsmslSGOyU+mpTamlaIW7aNKi90ZQZ9DFaZL3YRoiSCULQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/typescript": {
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
@@ -1531,10 +1579,16 @@
       "dev": true
     },
     "@fermyon/spin-sdk": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@fermyon/spin-sdk/-/spin-sdk-0.4.1.tgz",
-      "integrity": "sha512-EeiHN9p++1y0U2JwBYdU0k0h5qTv6wHxL0F8mTia/DbBsYwUziCHr7VWAGP5+DVmmvLuzC+mEhs9AM+ajVsQJQ==",
-      "dev": true
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@fermyon/spin-sdk/-/spin-sdk-0.5.0.tgz",
+      "integrity": "sha512-LMDEU+Zb+Sl0v/ZlTwKTpZ355wCanqs2jKIwbdnl89Rspllo/GhW/QzBgqRuMP1RidIdBXSorxhhufnmMnxQOQ==",
+      "dev": true,
+      "requires": {
+        "Buffer": "^0.0.0",
+        "fast-text-encoding": "^1.0.6",
+        "itty-router": "^3.0.12",
+        "typedarray-to-buffer": "^4.0.0"
+      }
     },
     "@jridgewell/gen-mapping": {
       "version": "0.3.2",
@@ -1866,6 +1920,12 @@
         "update-browserslist-db": "^1.0.10"
       }
     },
+    "Buffer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/Buffer/-/Buffer-0.0.0.tgz",
+      "integrity": "sha512-+zdncl8lI5TCkARStn9F1BwcuJYofYmD0oEHe5FNfCvGfeDJwf6+dSikCdQN6BMXXmHMhNNUagBN367WST1AIQ==",
+      "dev": true
+    },
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -2028,6 +2088,12 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
+    "fast-text-encoding": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
+      "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==",
+      "dev": true
+    },
     "fastest-levenshtein": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -2136,6 +2202,12 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "dev": true
+    },
+    "itty-router": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-3.0.12.tgz",
+      "integrity": "sha512-s98XTPhle6GGbaFf0kYrOD3Q8gyhnqvOqkwYijC3AmkceNKqWUp13YHg6dWmqmVv4pP7l7c94XI92I0EXVGO0w==",
       "dev": true
     },
     "jest-worker": {
@@ -2499,6 +2571,12 @@
         "micromatch": "^4.0.0",
         "semver": "^7.3.4"
       }
+    },
+    "typedarray-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-6dOYeZfS3O9RtRD1caom0sMxgK59b27+IwoNy8RDPsmslSGOyU+mpTamlaIW7aNKi90ZQZ9DFaZL3YRoiSCULQ==",
+      "dev": true
     },
     "typescript": {
       "version": "4.9.5",

--- a/spin/apps/01-getting-started/hello-typescript/package.json
+++ b/spin/apps/01-getting-started/hello-typescript/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@fermyon/spin-sdk": "^0.4.1",
+    "@fermyon/spin-sdk": "^0.5.0",
     "ts-loader": "^9.4.1",
     "typescript": "^4.8.4",
     "webpack": "^5.74.0",

--- a/spin/apps/02-json-api/magic-8-ball-ts/package-lock.json
+++ b/spin/apps/02-json-api/magic-8-ball-ts/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@fermyon/spin-sdk": "^0.4.1",
+        "@fermyon/spin-sdk": "^0.5.0",
         "ts-loader": "^9.4.1",
         "typescript": "^4.8.4",
         "webpack": "^5.74.0",
@@ -26,10 +26,17 @@
       }
     },
     "node_modules/@fermyon/spin-sdk": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@fermyon/spin-sdk/-/spin-sdk-0.4.1.tgz",
-      "integrity": "sha512-EeiHN9p++1y0U2JwBYdU0k0h5qTv6wHxL0F8mTia/DbBsYwUziCHr7VWAGP5+DVmmvLuzC+mEhs9AM+ajVsQJQ==",
-      "dev": true
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@fermyon/spin-sdk/-/spin-sdk-0.5.0.tgz",
+      "integrity": "sha512-LMDEU+Zb+Sl0v/ZlTwKTpZ355wCanqs2jKIwbdnl89Rspllo/GhW/QzBgqRuMP1RidIdBXSorxhhufnmMnxQOQ==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "npm:Buffer@^0.0.0",
+        "Buffer": "^0.0.0",
+        "fast-text-encoding": "^1.0.6",
+        "itty-router": "^3.0.12",
+        "typedarray-to-buffer": "^4.0.0"
+      }
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.2",
@@ -422,6 +429,15 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/Buffer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/Buffer/-/Buffer-0.0.0.tgz",
+      "integrity": "sha512-+zdncl8lI5TCkARStn9F1BwcuJYofYmD0oEHe5FNfCvGfeDJwf6+dSikCdQN6BMXXmHMhNNUagBN367WST1AIQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.2.0"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -637,6 +653,12 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
+    "node_modules/fast-text-encoding": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
+      "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==",
+      "dev": true
+    },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -785,6 +807,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/itty-router": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-3.0.12.tgz",
+      "integrity": "sha512-s98XTPhle6GGbaFf0kYrOD3Q8gyhnqvOqkwYijC3AmkceNKqWUp13YHg6dWmqmVv4pP7l7c94XI92I0EXVGO0w==",
+      "dev": true
     },
     "node_modules/jest-worker": {
       "version": "27.5.1",
@@ -1309,6 +1337,26 @@
         "webpack": "^5.0.0"
       }
     },
+    "node_modules/typedarray-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-6dOYeZfS3O9RtRD1caom0sMxgK59b27+IwoNy8RDPsmslSGOyU+mpTamlaIW7aNKi90ZQZ9DFaZL3YRoiSCULQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/typescript": {
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
@@ -1531,10 +1579,16 @@
       "dev": true
     },
     "@fermyon/spin-sdk": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@fermyon/spin-sdk/-/spin-sdk-0.4.1.tgz",
-      "integrity": "sha512-EeiHN9p++1y0U2JwBYdU0k0h5qTv6wHxL0F8mTia/DbBsYwUziCHr7VWAGP5+DVmmvLuzC+mEhs9AM+ajVsQJQ==",
-      "dev": true
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@fermyon/spin-sdk/-/spin-sdk-0.5.0.tgz",
+      "integrity": "sha512-LMDEU+Zb+Sl0v/ZlTwKTpZ355wCanqs2jKIwbdnl89Rspllo/GhW/QzBgqRuMP1RidIdBXSorxhhufnmMnxQOQ==",
+      "dev": true,
+      "requires": {
+        "Buffer": "^0.0.0",
+        "fast-text-encoding": "^1.0.6",
+        "itty-router": "^3.0.12",
+        "typedarray-to-buffer": "^4.0.0"
+      }
     },
     "@jridgewell/gen-mapping": {
       "version": "0.3.2",
@@ -1866,6 +1920,12 @@
         "update-browserslist-db": "^1.0.10"
       }
     },
+    "Buffer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/Buffer/-/Buffer-0.0.0.tgz",
+      "integrity": "sha512-+zdncl8lI5TCkARStn9F1BwcuJYofYmD0oEHe5FNfCvGfeDJwf6+dSikCdQN6BMXXmHMhNNUagBN367WST1AIQ==",
+      "dev": true
+    },
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -2028,6 +2088,12 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
+    "fast-text-encoding": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
+      "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==",
+      "dev": true
+    },
     "fastest-levenshtein": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -2136,6 +2202,12 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "dev": true
+    },
+    "itty-router": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-3.0.12.tgz",
+      "integrity": "sha512-s98XTPhle6GGbaFf0kYrOD3Q8gyhnqvOqkwYijC3AmkceNKqWUp13YHg6dWmqmVv4pP7l7c94XI92I0EXVGO0w==",
       "dev": true
     },
     "jest-worker": {
@@ -2499,6 +2571,12 @@
         "micromatch": "^4.0.0",
         "semver": "^7.3.4"
       }
+    },
+    "typedarray-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-6dOYeZfS3O9RtRD1caom0sMxgK59b27+IwoNy8RDPsmslSGOyU+mpTamlaIW7aNKi90ZQZ9DFaZL3YRoiSCULQ==",
+      "dev": true
     },
     "typescript": {
       "version": "4.9.5",

--- a/spin/apps/02-json-api/magic-8-ball-ts/package.json
+++ b/spin/apps/02-json-api/magic-8-ball-ts/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@fermyon/spin-sdk": "^0.4.1",
+    "@fermyon/spin-sdk": "^0.5.0",
     "ts-loader": "^9.4.1",
     "typescript": "^4.8.4",
     "webpack": "^5.74.0",

--- a/spin/apps/02b-json-api-openai/dist/spin.js
+++ b/spin/apps/02b-json-api-openai/dist/spin.js
@@ -1,0 +1,315 @@
+var spin;
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 54:
+/***/ ((module) => {
+
+/*! typedarray-to-buffer. MIT License. Feross Aboukhadijeh <https://feross.org/opensource> */
+/**
+ * Convert a typed array to a Buffer without a copy
+ *
+ * Author:   Feross Aboukhadijeh <https://feross.org>
+ * License:  MIT
+ *
+ * `npm install typedarray-to-buffer`
+ */
+
+module.exports = function typedarrayToBuffer (arr) {
+  return ArrayBuffer.isView(arr)
+    // To avoid a copy, use the typed array's underlying ArrayBuffer to back
+    // new Buffer, respecting the "view", i.e. byteOffset and byteLength
+    ? Buffer.from(arr.buffer, arr.byteOffset, arr.byteLength)
+    // Pass through all other types to `Buffer.from`
+    : Buffer.from(arr)
+}
+
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	(() => {
+/******/ 		// getDefaultExport function for compatibility with non-harmony modules
+/******/ 		__webpack_require__.n = (module) => {
+/******/ 			var getter = module && module.__esModule ?
+/******/ 				() => (module['default']) :
+/******/ 				() => (module);
+/******/ 			__webpack_require__.d(getter, { a: getter });
+/******/ 			return getter;
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	(() => {
+/******/ 		// define getter functions for harmony exports
+/******/ 		__webpack_require__.d = (exports, definition) => {
+/******/ 			for(var key in definition) {
+/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 				}
+/******/ 			}
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	(() => {
+/******/ 		__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/make namespace object */
+/******/ 	(() => {
+/******/ 		// define __esModule on exports
+/******/ 		__webpack_require__.r = (exports) => {
+/******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 			}
+/******/ 			Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/************************************************************************/
+var __webpack_exports__ = {};
+// This entry need to be wrapped in an IIFE because it need to be in strict mode.
+(() => {
+"use strict";
+// ESM COMPAT FLAG
+__webpack_require__.r(__webpack_exports__);
+
+// EXPORTS
+__webpack_require__.d(__webpack_exports__, {
+  handleRequest: () => (/* binding */ handleRequest)
+});
+
+;// CONCATENATED MODULE: ./node_modules/itty-router/dist/itty-router.mjs
+const e=({base:e="",routes:r=[]}={})=>({__proto__:new Proxy({},{get:(a,o,t)=>(a,...p)=>r.push([o.toUpperCase(),RegExp(`^${(e+a).replace(/(\/?)\*/g,"($1.*)?").replace(/(\/$)|((?<=\/)\/)/,"").replace(/(:(\w+)\+)/,"(?<$2>.*)").replace(/:(\w+)(\?)?(\.)?/g,"$2(?<$1>[^/]+)$2$3").replace(/\.(?=[\w(])/,"\\.").replace(/\)\.\?\(([^\[]+)\[\^/g,"?)\\.?($1(?<=\\.)[^\\.")}/*$`),p])&&t}),routes:r,async handle(e,...a){let o,t,p=new URL(e.url),l=e.query={};for(let[e,r]of p.searchParams)l[e]=void 0===l[e]?r:[l[e],r].flat();for(let[l,s,c]of r)if((l===e.method||"ALL"===l)&&(t=p.pathname.match(s))){e.params=t.groups||{};for(let r of c)if(void 0!==(o=await r(e.proxy||e,...a)))return o}}});
+
+;// CONCATENATED MODULE: ./node_modules/@fermyon/spin-sdk/lib/modules/router.js
+/** @internal */
+
+/** @internal */
+function router() {
+    let _spinRouter = e();
+    return {
+        all: function (path, ...handlers) { return _spinRouter.all(path, ...handlers); },
+        delete: function (path, ...handlers) { return _spinRouter.delete(path, ...handlers); },
+        get: function (path, ...handlers) { return _spinRouter.get(path, ...handlers); },
+        handle: function (request, ...extra) { return _spinRouter.handle(request, ...extra); },
+        handleRequest: function (request, ...a) {
+            return _spinRouter.handle({
+                method: request.method,
+                url: request.headers["spin-full-url"]
+            }, ...a);
+        },
+        options: function (path, ...handlers) { return _spinRouter.options(path, ...handlers); },
+        patch: function (path, ...handlers) { return _spinRouter.patch(path, ...handlers); },
+        post: function (path, ...handlers) { return _spinRouter.post(path, ...handlers); },
+        put: function (path, ...handlers) { return _spinRouter.put(path, ...handlers); },
+        routes: _spinRouter.routes
+    };
+}
+
+
+// EXTERNAL MODULE: ./node_modules/typedarray-to-buffer/index.js
+var typedarray_to_buffer = __webpack_require__(54);
+var typedarray_to_buffer_default = /*#__PURE__*/__webpack_require__.n(typedarray_to_buffer);
+;// CONCATENATED MODULE: ./node_modules/@fermyon/spin-sdk/lib/modules/utils.js
+
+const utils = {
+    toBuffer(arg0) {
+        return typedarray_to_buffer_default()(arg0);
+    },
+};
+
+
+;// CONCATENATED MODULE: ./node_modules/@fermyon/spin-sdk/lib/modules/spinSdk.js
+
+
+const kv = {
+    open: (name) => {
+        let store = __internal__.spin_sdk.kv.open(name);
+        store.getJson = (key) => {
+            return JSON.parse(new TextDecoder().decode(store.get(key)));
+        };
+        store.setJson = (key, value) => {
+            store.set(key, JSON.stringify(value));
+        };
+        return store;
+    },
+    openDefault: () => {
+        let store = kv.open("default");
+        return store;
+    }
+};
+/**  features
+ */
+/** @deprecated */
+const spinSdk = {
+    config: __internal__.spin_sdk.config,
+    redis: __internal__.spin_sdk.redis,
+    kv: kv,
+    mysql: __internal__.spin_sdk.mysql,
+    pg: __internal__.spin_sdk.pg,
+    sqlite: __internal__.spin_sdk.sqlite,
+    utils: utils,
+    Router: () => {
+        return router();
+    }
+};
+const Config = __internal__.spin_sdk.config;
+const Redis = __internal__.spin_sdk.redis;
+const Kv = (/* unused pure expression or super */ null && (kv));
+const Mysql = __internal__.spin_sdk.mysql;
+const Pg = __internal__.spin_sdk.pg;
+const Sqlite = __internal__.spin_sdk.sqlite;
+
+
+
+;// CONCATENATED MODULE: ./node_modules/@fermyon/spin-sdk/lib/index.js
+
+
+
+
+
+
+
+;// CONCATENATED MODULE: ./src/index.ts
+var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (undefined && undefined.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (g && (g = 0, op[0] && (_ = 0)), _) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+
+var encoder = new TextEncoder();
+var decoder = new TextDecoder("utf-8");
+var handleRequest = function (request) {
+    var _a;
+    return __awaiter(this, void 0, void 0, function () {
+        var question, openai_key, apiUrl, requestData, options, response, decoded, _b, _c, parsed, answerJson;
+        return __generator(this, function (_d) {
+            switch (_d.label) {
+                case 0:
+                    question = decoder.decode(request.body);
+                    console.log("<------->");
+                    console.log("Question Received: " + question);
+                    openai_key = Config.get("openai_key");
+                    apiUrl = 'https://api.openai.com/v1/chat/completions';
+                    requestData = JSON.stringify({
+                        "model": "gpt-3.5-turbo",
+                        "messages": [
+                            {
+                                "role": "system",
+                                "content": "Always restrict your answers to 5 words or less."
+                            },
+                            {
+                                "role": "user",
+                                "content": "" + question
+                            }
+                        ],
+                        "temperature": 1,
+                        "top_p": 1,
+                        "n": 1,
+                        "stream": false,
+                        "max_tokens": 250,
+                        "presence_penalty": 0,
+                        "frequency_penalty": 0
+                    });
+                    options = {
+                        hostname: 'api.openai.com',
+                        path: '/v1/chat/completions',
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'Accept': 'application/json',
+                            'Authorization': "Bearer ".concat(openai_key) // Replace with your actual API token
+                        },
+                        body: requestData
+                    };
+                    return [4 /*yield*/, fetch(apiUrl, options)];
+                case 1:
+                    response = _d.sent();
+                    _c = (_b = decoder).decode;
+                    return [4 /*yield*/, response.arrayBuffer()];
+                case 2:
+                    decoded = _c.apply(_b, [(_d.sent()) || new Uint8Array()]);
+                    parsed = JSON.parse(decoded);
+                    if ((_a = parsed === null || parsed === void 0 ? void 0 : parsed.choices[0]) === null || _a === void 0 ? void 0 : _a.message) {
+                        console.log("Generated Answer: " + JSON.stringify(parsed.choices[0].message.content));
+                        answerJson = "{\"answer\": \"".concat(parsed.choices[0].message.content, "\"}");
+                        return [2 /*return*/, {
+                                status: 200,
+                                headers: { "Content-Type": "application/json" },
+                                body: answerJson
+                            }];
+                    }
+                    return [2 /*return*/, {
+                            status: 500,
+                            body: encoder.encode("Something went wrong").buffer
+                        }];
+            }
+        });
+    });
+};
+
+})();
+
+spin = __webpack_exports__;
+/******/ })()
+;

--- a/spin/apps/02b-json-api-openai/package-lock.json
+++ b/spin/apps/02b-json-api-openai/package-lock.json
@@ -8,11 +8,8 @@
       "name": "magic-8-ball",
       "version": "1.0.0",
       "license": "ISC",
-      "dependencies": {
-        "openai": "^3.2.1"
-      },
       "devDependencies": {
-        "@fermyon/spin-sdk": "^0.4.1",
+        "@fermyon/spin-sdk": "^0.5.0",
         "ts-loader": "^9.4.1",
         "typescript": "^4.8.4",
         "webpack": "^5.74.0",
@@ -29,10 +26,17 @@
       }
     },
     "node_modules/@fermyon/spin-sdk": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@fermyon/spin-sdk/-/spin-sdk-0.4.1.tgz",
-      "integrity": "sha512-EeiHN9p++1y0U2JwBYdU0k0h5qTv6wHxL0F8mTia/DbBsYwUziCHr7VWAGP5+DVmmvLuzC+mEhs9AM+ajVsQJQ==",
-      "dev": true
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@fermyon/spin-sdk/-/spin-sdk-0.5.0.tgz",
+      "integrity": "sha512-LMDEU+Zb+Sl0v/ZlTwKTpZ355wCanqs2jKIwbdnl89Rspllo/GhW/QzBgqRuMP1RidIdBXSorxhhufnmMnxQOQ==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "npm:Buffer@^0.0.0",
+        "Buffer": "^0.0.0",
+        "fast-text-encoding": "^1.0.6",
+        "itty-router": "^3.0.12",
+        "typedarray-to-buffer": "^4.0.0"
+      }
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.3",
@@ -385,19 +389,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-    },
-    "node_modules/axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-      "dependencies": {
-        "follow-redirects": "^1.14.8"
-      }
-    },
     "node_modules/braces": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
@@ -440,6 +431,15 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/Buffer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/Buffer/-/Buffer-0.0.0.tgz",
+      "integrity": "sha512-+zdncl8lI5TCkARStn9F1BwcuJYofYmD0oEHe5FNfCvGfeDJwf6+dSikCdQN6BMXXmHMhNNUagBN367WST1AIQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.2.0"
       }
     },
     "node_modules/buffer-from": {
@@ -531,17 +531,6 @@
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -560,14 +549,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -680,6 +661,12 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
+    "node_modules/fast-text-encoding": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
+      "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==",
+      "dev": true
+    },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -712,38 +699,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/function-bind": {
@@ -861,6 +816,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/itty-router": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-3.0.12.tgz",
+      "integrity": "sha512-s98XTPhle6GGbaFf0kYrOD3Q8gyhnqvOqkwYijC3AmkceNKqWUp13YHg6dWmqmVv4pP7l7c94XI92I0EXVGO0w==",
+      "dev": true
+    },
     "node_modules/jest-worker": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
@@ -967,6 +928,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -975,6 +937,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -993,15 +956,6 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
       "integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==",
       "dev": true
-    },
-    "node_modules/openai": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-3.2.1.tgz",
-      "integrity": "sha512-762C9BNlJPbjjlWZi4WYK9iM2tAVAv0uUp1UmI34vb0CN5T2mjB/qM6RYBmNKMh/dN9fC+bxqPwWJZUTWW052A==",
-      "dependencies": {
-        "axios": "^0.26.0",
-        "form-data": "^4.0.0"
-      }
     },
     "node_modules/p-limit": {
       "version": "2.3.0",
@@ -1390,6 +1344,26 @@
         "typescript": "*",
         "webpack": "^5.0.0"
       }
+    },
+    "node_modules/typedarray-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-6dOYeZfS3O9RtRD1caom0sMxgK59b27+IwoNy8RDPsmslSGOyU+mpTamlaIW7aNKi90ZQZ9DFaZL3YRoiSCULQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/typescript": {
       "version": "4.9.5",

--- a/spin/apps/02b-json-api-openai/package.json
+++ b/spin/apps/02b-json-api-openai/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@fermyon/spin-sdk": "^0.4.1",
+    "@fermyon/spin-sdk": "^0.5.0",
     "ts-loader": "^9.4.1",
     "typescript": "^4.8.4",
     "webpack": "^5.74.0",

--- a/spin/apps/02b-json-api-openai/src/index.ts
+++ b/spin/apps/02b-json-api-openai/src/index.ts
@@ -1,4 +1,4 @@
-import { HandleRequest, HttpRequest, HttpResponse } from "@fermyon/spin-sdk"
+import { HandleRequest, HttpRequest, HttpResponse, Config } from "@fermyon/spin-sdk"
 
 
 const encoder = new TextEncoder()
@@ -10,7 +10,7 @@ export const handleRequest: HandleRequest = async function (request: HttpRequest
 
   console.log("<------->")
   console.log("Question Received: " + question)
-  let openai_key = spinSdk.config.get("openai_key");
+  let openai_key = Config.get("openai_key");
   const apiUrl = 'https://api.openai.com/v1/chat/completions';
   const requestData = JSON.stringify({
     "model": "gpt-3.5-turbo",

--- a/spin/apps/03-front-end/magic-8-ball-ts/package-lock.json
+++ b/spin/apps/03-front-end/magic-8-ball-ts/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@fermyon/spin-sdk": "^0.4.1",
+        "@fermyon/spin-sdk": "^0.5.0",
         "ts-loader": "^9.4.1",
         "typescript": "^4.8.4",
         "webpack": "^5.74.0",
@@ -26,10 +26,17 @@
       }
     },
     "node_modules/@fermyon/spin-sdk": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@fermyon/spin-sdk/-/spin-sdk-0.4.1.tgz",
-      "integrity": "sha512-EeiHN9p++1y0U2JwBYdU0k0h5qTv6wHxL0F8mTia/DbBsYwUziCHr7VWAGP5+DVmmvLuzC+mEhs9AM+ajVsQJQ==",
-      "dev": true
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@fermyon/spin-sdk/-/spin-sdk-0.5.0.tgz",
+      "integrity": "sha512-LMDEU+Zb+Sl0v/ZlTwKTpZ355wCanqs2jKIwbdnl89Rspllo/GhW/QzBgqRuMP1RidIdBXSorxhhufnmMnxQOQ==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "npm:Buffer@^0.0.0",
+        "Buffer": "^0.0.0",
+        "fast-text-encoding": "^1.0.6",
+        "itty-router": "^3.0.12",
+        "typedarray-to-buffer": "^4.0.0"
+      }
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.2",
@@ -422,6 +429,15 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/Buffer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/Buffer/-/Buffer-0.0.0.tgz",
+      "integrity": "sha512-+zdncl8lI5TCkARStn9F1BwcuJYofYmD0oEHe5FNfCvGfeDJwf6+dSikCdQN6BMXXmHMhNNUagBN367WST1AIQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.2.0"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -637,6 +653,12 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
+    "node_modules/fast-text-encoding": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
+      "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==",
+      "dev": true
+    },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -785,6 +807,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/itty-router": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-3.0.12.tgz",
+      "integrity": "sha512-s98XTPhle6GGbaFf0kYrOD3Q8gyhnqvOqkwYijC3AmkceNKqWUp13YHg6dWmqmVv4pP7l7c94XI92I0EXVGO0w==",
+      "dev": true
     },
     "node_modules/jest-worker": {
       "version": "27.5.1",
@@ -1309,6 +1337,26 @@
         "webpack": "^5.0.0"
       }
     },
+    "node_modules/typedarray-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-6dOYeZfS3O9RtRD1caom0sMxgK59b27+IwoNy8RDPsmslSGOyU+mpTamlaIW7aNKi90ZQZ9DFaZL3YRoiSCULQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/typescript": {
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
@@ -1531,10 +1579,16 @@
       "dev": true
     },
     "@fermyon/spin-sdk": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@fermyon/spin-sdk/-/spin-sdk-0.4.1.tgz",
-      "integrity": "sha512-EeiHN9p++1y0U2JwBYdU0k0h5qTv6wHxL0F8mTia/DbBsYwUziCHr7VWAGP5+DVmmvLuzC+mEhs9AM+ajVsQJQ==",
-      "dev": true
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@fermyon/spin-sdk/-/spin-sdk-0.5.0.tgz",
+      "integrity": "sha512-LMDEU+Zb+Sl0v/ZlTwKTpZ355wCanqs2jKIwbdnl89Rspllo/GhW/QzBgqRuMP1RidIdBXSorxhhufnmMnxQOQ==",
+      "dev": true,
+      "requires": {
+        "Buffer": "^0.0.0",
+        "fast-text-encoding": "^1.0.6",
+        "itty-router": "^3.0.12",
+        "typedarray-to-buffer": "^4.0.0"
+      }
     },
     "@jridgewell/gen-mapping": {
       "version": "0.3.2",
@@ -1866,6 +1920,12 @@
         "update-browserslist-db": "^1.0.10"
       }
     },
+    "Buffer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/Buffer/-/Buffer-0.0.0.tgz",
+      "integrity": "sha512-+zdncl8lI5TCkARStn9F1BwcuJYofYmD0oEHe5FNfCvGfeDJwf6+dSikCdQN6BMXXmHMhNNUagBN367WST1AIQ==",
+      "dev": true
+    },
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -2028,6 +2088,12 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
+    "fast-text-encoding": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
+      "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==",
+      "dev": true
+    },
     "fastest-levenshtein": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -2136,6 +2202,12 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "dev": true
+    },
+    "itty-router": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-3.0.12.tgz",
+      "integrity": "sha512-s98XTPhle6GGbaFf0kYrOD3Q8gyhnqvOqkwYijC3AmkceNKqWUp13YHg6dWmqmVv4pP7l7c94XI92I0EXVGO0w==",
       "dev": true
     },
     "jest-worker": {
@@ -2499,6 +2571,12 @@
         "micromatch": "^4.0.0",
         "semver": "^7.3.4"
       }
+    },
+    "typedarray-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-6dOYeZfS3O9RtRD1caom0sMxgK59b27+IwoNy8RDPsmslSGOyU+mpTamlaIW7aNKi90ZQZ9DFaZL3YRoiSCULQ==",
+      "dev": true
     },
     "typescript": {
       "version": "4.9.5",

--- a/spin/apps/03-front-end/magic-8-ball-ts/package.json
+++ b/spin/apps/03-front-end/magic-8-ball-ts/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@fermyon/spin-sdk": "^0.4.1",
+    "@fermyon/spin-sdk": "^0.5.0",
     "ts-loader": "^9.4.1",
     "typescript": "^4.8.4",
     "webpack": "^5.74.0",

--- a/spin/apps/03-front-end/magic-8-ball-ts/src/index.ts
+++ b/spin/apps/03-front-end/magic-8-ball-ts/src/index.ts
@@ -2,13 +2,13 @@ import { HandleRequest, HttpRequest, HttpResponse } from "@fermyon/spin-sdk"
 
 const encoder = new TextEncoder()
 
-export const handleRequest: HandleRequest = async function(request: HttpRequest): Promise<HttpResponse> {
-    let answerJson = `{\"answer\": \"${answer()}\"}`;
-    return {
-      status: 200,
-        headers: { "Content-Type": "application/json" },
-      body: answerJson
-    }
+export const handleRequest: HandleRequest = async function (request: HttpRequest): Promise<HttpResponse> {
+  let answerJson = `{\"answer\": \"${answer()}\"}`;
+  return {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    body: answerJson
+  }
 }
 
 function answer(): string {

--- a/spin/apps/05-spin-kv/magic-8-ball-ts/package-lock.json
+++ b/spin/apps/05-spin-kv/magic-8-ball-ts/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@fermyon/spin-sdk": "^0.4.1",
+        "@fermyon/spin-sdk": "^0.5.0",
         "ts-loader": "^9.4.1",
         "typescript": "^4.8.4",
         "webpack": "^5.74.0",
@@ -26,10 +26,17 @@
       }
     },
     "node_modules/@fermyon/spin-sdk": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@fermyon/spin-sdk/-/spin-sdk-0.4.1.tgz",
-      "integrity": "sha512-EeiHN9p++1y0U2JwBYdU0k0h5qTv6wHxL0F8mTia/DbBsYwUziCHr7VWAGP5+DVmmvLuzC+mEhs9AM+ajVsQJQ==",
-      "dev": true
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@fermyon/spin-sdk/-/spin-sdk-0.5.0.tgz",
+      "integrity": "sha512-LMDEU+Zb+Sl0v/ZlTwKTpZ355wCanqs2jKIwbdnl89Rspllo/GhW/QzBgqRuMP1RidIdBXSorxhhufnmMnxQOQ==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "npm:Buffer@^0.0.0",
+        "Buffer": "^0.0.0",
+        "fast-text-encoding": "^1.0.6",
+        "itty-router": "^3.0.12",
+        "typedarray-to-buffer": "^4.0.0"
+      }
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.2",
@@ -422,6 +429,15 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/Buffer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/Buffer/-/Buffer-0.0.0.tgz",
+      "integrity": "sha512-+zdncl8lI5TCkARStn9F1BwcuJYofYmD0oEHe5FNfCvGfeDJwf6+dSikCdQN6BMXXmHMhNNUagBN367WST1AIQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.2.0"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -637,6 +653,12 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
+    "node_modules/fast-text-encoding": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
+      "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==",
+      "dev": true
+    },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -785,6 +807,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/itty-router": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-3.0.12.tgz",
+      "integrity": "sha512-s98XTPhle6GGbaFf0kYrOD3Q8gyhnqvOqkwYijC3AmkceNKqWUp13YHg6dWmqmVv4pP7l7c94XI92I0EXVGO0w==",
+      "dev": true
     },
     "node_modules/jest-worker": {
       "version": "27.5.1",
@@ -1309,6 +1337,26 @@
         "webpack": "^5.0.0"
       }
     },
+    "node_modules/typedarray-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-6dOYeZfS3O9RtRD1caom0sMxgK59b27+IwoNy8RDPsmslSGOyU+mpTamlaIW7aNKi90ZQZ9DFaZL3YRoiSCULQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/typescript": {
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
@@ -1531,10 +1579,16 @@
       "dev": true
     },
     "@fermyon/spin-sdk": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@fermyon/spin-sdk/-/spin-sdk-0.4.1.tgz",
-      "integrity": "sha512-EeiHN9p++1y0U2JwBYdU0k0h5qTv6wHxL0F8mTia/DbBsYwUziCHr7VWAGP5+DVmmvLuzC+mEhs9AM+ajVsQJQ==",
-      "dev": true
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@fermyon/spin-sdk/-/spin-sdk-0.5.0.tgz",
+      "integrity": "sha512-LMDEU+Zb+Sl0v/ZlTwKTpZ355wCanqs2jKIwbdnl89Rspllo/GhW/QzBgqRuMP1RidIdBXSorxhhufnmMnxQOQ==",
+      "dev": true,
+      "requires": {
+        "Buffer": "^0.0.0",
+        "fast-text-encoding": "^1.0.6",
+        "itty-router": "^3.0.12",
+        "typedarray-to-buffer": "^4.0.0"
+      }
     },
     "@jridgewell/gen-mapping": {
       "version": "0.3.2",
@@ -1866,6 +1920,12 @@
         "update-browserslist-db": "^1.0.10"
       }
     },
+    "Buffer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/Buffer/-/Buffer-0.0.0.tgz",
+      "integrity": "sha512-+zdncl8lI5TCkARStn9F1BwcuJYofYmD0oEHe5FNfCvGfeDJwf6+dSikCdQN6BMXXmHMhNNUagBN367WST1AIQ==",
+      "dev": true
+    },
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -2028,6 +2088,12 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
+    "fast-text-encoding": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
+      "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==",
+      "dev": true
+    },
     "fastest-levenshtein": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -2136,6 +2202,12 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "dev": true
+    },
+    "itty-router": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-3.0.12.tgz",
+      "integrity": "sha512-s98XTPhle6GGbaFf0kYrOD3Q8gyhnqvOqkwYijC3AmkceNKqWUp13YHg6dWmqmVv4pP7l7c94XI92I0EXVGO0w==",
       "dev": true
     },
     "jest-worker": {
@@ -2499,6 +2571,12 @@
         "micromatch": "^4.0.0",
         "semver": "^7.3.4"
       }
+    },
+    "typedarray-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-6dOYeZfS3O9RtRD1caom0sMxgK59b27+IwoNy8RDPsmslSGOyU+mpTamlaIW7aNKi90ZQZ9DFaZL3YRoiSCULQ==",
+      "dev": true
     },
     "typescript": {
       "version": "4.9.5",

--- a/spin/apps/05-spin-kv/magic-8-ball-ts/package.json
+++ b/spin/apps/05-spin-kv/magic-8-ball-ts/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@fermyon/spin-sdk": "^0.4.1",
+    "@fermyon/spin-sdk": "^0.5.0",
     "ts-loader": "^9.4.1",
     "typescript": "^4.8.4",
     "webpack": "^5.74.0",

--- a/spin/apps/05-spin-kv/magic-8-ball-ts/src/index.ts
+++ b/spin/apps/05-spin-kv/magic-8-ball-ts/src/index.ts
@@ -1,20 +1,20 @@
-import { HandleRequest, HttpRequest, HttpResponse} from "@fermyon/spin-sdk"
+import { HandleRequest, HttpRequest, HttpResponse, Kv } from "@fermyon/spin-sdk"
 
 const encoder = new TextEncoder()
 const decoder = new TextDecoder()
 
-export const handleRequest: HandleRequest = async function(request: HttpRequest): Promise<HttpResponse> {
-    let question = decoder.decode(request.body);
-    let answerJson = `{\"answer\": \"${getOrSetAnswer(question)}\"}`;
-    return {
-      status: 200,
-        headers: { "Content-Type": "application/json" },
-      body: answerJson
-    }
+export const handleRequest: HandleRequest = async function (request: HttpRequest): Promise<HttpResponse> {
+  let question = decoder.decode(request.body);
+  let answerJson = `{\"answer\": \"${getOrSetAnswer(question)}\"}`;
+  return {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    body: answerJson
+  }
 }
 
 function getOrSetAnswer(question: string): string {
-  let store = spinSdk.kv.openDefault();
+  let store = Kv.openDefault();
   let response = "";
   if (store.exists(question)) {
     response = decoder.decode(store.get(question));

--- a/spin/apps/06-external-db/magic-8-ball-ts/package-lock.json
+++ b/spin/apps/06-external-db/magic-8-ball-ts/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@fermyon/spin-sdk": "^0.4.1",
+        "@fermyon/spin-sdk": "^0.5.0",
         "ts-loader": "^9.4.1",
         "typescript": "^4.8.4",
         "webpack": "^5.74.0",
@@ -26,10 +26,17 @@
       }
     },
     "node_modules/@fermyon/spin-sdk": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@fermyon/spin-sdk/-/spin-sdk-0.4.1.tgz",
-      "integrity": "sha512-EeiHN9p++1y0U2JwBYdU0k0h5qTv6wHxL0F8mTia/DbBsYwUziCHr7VWAGP5+DVmmvLuzC+mEhs9AM+ajVsQJQ==",
-      "dev": true
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@fermyon/spin-sdk/-/spin-sdk-0.5.0.tgz",
+      "integrity": "sha512-LMDEU+Zb+Sl0v/ZlTwKTpZ355wCanqs2jKIwbdnl89Rspllo/GhW/QzBgqRuMP1RidIdBXSorxhhufnmMnxQOQ==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "npm:Buffer@^0.0.0",
+        "Buffer": "^0.0.0",
+        "fast-text-encoding": "^1.0.6",
+        "itty-router": "^3.0.12",
+        "typedarray-to-buffer": "^4.0.0"
+      }
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.2",
@@ -422,6 +429,15 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/Buffer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/Buffer/-/Buffer-0.0.0.tgz",
+      "integrity": "sha512-+zdncl8lI5TCkARStn9F1BwcuJYofYmD0oEHe5FNfCvGfeDJwf6+dSikCdQN6BMXXmHMhNNUagBN367WST1AIQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.2.0"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -637,6 +653,12 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
+    "node_modules/fast-text-encoding": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
+      "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==",
+      "dev": true
+    },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -785,6 +807,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/itty-router": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-3.0.12.tgz",
+      "integrity": "sha512-s98XTPhle6GGbaFf0kYrOD3Q8gyhnqvOqkwYijC3AmkceNKqWUp13YHg6dWmqmVv4pP7l7c94XI92I0EXVGO0w==",
+      "dev": true
     },
     "node_modules/jest-worker": {
       "version": "27.5.1",
@@ -1309,6 +1337,26 @@
         "webpack": "^5.0.0"
       }
     },
+    "node_modules/typedarray-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-6dOYeZfS3O9RtRD1caom0sMxgK59b27+IwoNy8RDPsmslSGOyU+mpTamlaIW7aNKi90ZQZ9DFaZL3YRoiSCULQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/typescript": {
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
@@ -1531,10 +1579,16 @@
       "dev": true
     },
     "@fermyon/spin-sdk": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@fermyon/spin-sdk/-/spin-sdk-0.4.1.tgz",
-      "integrity": "sha512-EeiHN9p++1y0U2JwBYdU0k0h5qTv6wHxL0F8mTia/DbBsYwUziCHr7VWAGP5+DVmmvLuzC+mEhs9AM+ajVsQJQ==",
-      "dev": true
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@fermyon/spin-sdk/-/spin-sdk-0.5.0.tgz",
+      "integrity": "sha512-LMDEU+Zb+Sl0v/ZlTwKTpZ355wCanqs2jKIwbdnl89Rspllo/GhW/QzBgqRuMP1RidIdBXSorxhhufnmMnxQOQ==",
+      "dev": true,
+      "requires": {
+        "Buffer": "^0.0.0",
+        "fast-text-encoding": "^1.0.6",
+        "itty-router": "^3.0.12",
+        "typedarray-to-buffer": "^4.0.0"
+      }
     },
     "@jridgewell/gen-mapping": {
       "version": "0.3.2",
@@ -1866,6 +1920,12 @@
         "update-browserslist-db": "^1.0.10"
       }
     },
+    "Buffer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/Buffer/-/Buffer-0.0.0.tgz",
+      "integrity": "sha512-+zdncl8lI5TCkARStn9F1BwcuJYofYmD0oEHe5FNfCvGfeDJwf6+dSikCdQN6BMXXmHMhNNUagBN367WST1AIQ==",
+      "dev": true
+    },
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -2028,6 +2088,12 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
+    "fast-text-encoding": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
+      "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==",
+      "dev": true
+    },
     "fastest-levenshtein": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -2136,6 +2202,12 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "dev": true
+    },
+    "itty-router": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-3.0.12.tgz",
+      "integrity": "sha512-s98XTPhle6GGbaFf0kYrOD3Q8gyhnqvOqkwYijC3AmkceNKqWUp13YHg6dWmqmVv4pP7l7c94XI92I0EXVGO0w==",
       "dev": true
     },
     "jest-worker": {
@@ -2499,6 +2571,12 @@
         "micromatch": "^4.0.0",
         "semver": "^7.3.4"
       }
+    },
+    "typedarray-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-6dOYeZfS3O9RtRD1caom0sMxgK59b27+IwoNy8RDPsmslSGOyU+mpTamlaIW7aNKi90ZQZ9DFaZL3YRoiSCULQ==",
+      "dev": true
     },
     "typescript": {
       "version": "4.9.5",

--- a/spin/apps/06-external-db/magic-8-ball-ts/package.json
+++ b/spin/apps/06-external-db/magic-8-ball-ts/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@fermyon/spin-sdk": "^0.4.1",
+    "@fermyon/spin-sdk": "^0.5.0",
     "ts-loader": "^9.4.1",
     "typescript": "^4.8.4",
     "webpack": "^5.74.0",

--- a/spin/apps/06-external-db/magic-8-ball-ts/src/index.ts
+++ b/spin/apps/06-external-db/magic-8-ball-ts/src/index.ts
@@ -1,24 +1,24 @@
-import { HandleRequest, HttpRequest, HttpResponse} from "@fermyon/spin-sdk"
+import { HandleRequest, HttpRequest, HttpResponse, Redis } from "@fermyon/spin-sdk"
 
 const encoder = new TextEncoder()
 const decoder = new TextDecoder()
 
-export const handleRequest: HandleRequest = async function(request: HttpRequest): Promise<HttpResponse> {
-    let question = decoder.decode(request.body);
-    let answerJson = `{\"answer\": \"${getOrSetAnswer(question)}\"}`;
-    return {
-      status: 200,
-        headers: { "Content-Type": "application/json" },
-      body: answerJson
-    }
+export const handleRequest: HandleRequest = async function (request: HttpRequest): Promise<HttpResponse> {
+  let question = decoder.decode(request.body);
+  let answerJson = `{\"answer\": \"${getOrSetAnswer(question)}\"}`;
+  return {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    body: answerJson
+  }
 }
 
 function getOrSetAnswer(question: string): string {
   let address = process.env["REDIS_ADDRESS"] as string;
-  let response = decoder.decode(spinSdk.redis.get(address, question));
-  if ( response.length == 0 || response == "Ask again later." ) {
+  let response = decoder.decode(Redis.get(address, question));
+  if (response.length == 0 || response == "Ask again later.") {
     response = answer();
-    spinSdk.redis.set(address, question, encoder.encode(response).buffer);
+    Redis.set(address, question, encoder.encode(response).buffer);
   }
   return response;
 }

--- a/spin/apps/07-kubernetes/magic-8-ball-ts/package-lock.json
+++ b/spin/apps/07-kubernetes/magic-8-ball-ts/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@fermyon/spin-sdk": "^0.4.1",
+        "@fermyon/spin-sdk": "^0.5.0",
         "ts-loader": "^9.4.1",
         "typescript": "^4.8.4",
         "webpack": "^5.74.0",
@@ -26,10 +26,17 @@
       }
     },
     "node_modules/@fermyon/spin-sdk": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@fermyon/spin-sdk/-/spin-sdk-0.4.1.tgz",
-      "integrity": "sha512-EeiHN9p++1y0U2JwBYdU0k0h5qTv6wHxL0F8mTia/DbBsYwUziCHr7VWAGP5+DVmmvLuzC+mEhs9AM+ajVsQJQ==",
-      "dev": true
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@fermyon/spin-sdk/-/spin-sdk-0.5.0.tgz",
+      "integrity": "sha512-LMDEU+Zb+Sl0v/ZlTwKTpZ355wCanqs2jKIwbdnl89Rspllo/GhW/QzBgqRuMP1RidIdBXSorxhhufnmMnxQOQ==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "npm:Buffer@^0.0.0",
+        "Buffer": "^0.0.0",
+        "fast-text-encoding": "^1.0.6",
+        "itty-router": "^3.0.12",
+        "typedarray-to-buffer": "^4.0.0"
+      }
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.2",
@@ -422,6 +429,15 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/Buffer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/Buffer/-/Buffer-0.0.0.tgz",
+      "integrity": "sha512-+zdncl8lI5TCkARStn9F1BwcuJYofYmD0oEHe5FNfCvGfeDJwf6+dSikCdQN6BMXXmHMhNNUagBN367WST1AIQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.2.0"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -637,6 +653,12 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
+    "node_modules/fast-text-encoding": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
+      "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==",
+      "dev": true
+    },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -785,6 +807,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/itty-router": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-3.0.12.tgz",
+      "integrity": "sha512-s98XTPhle6GGbaFf0kYrOD3Q8gyhnqvOqkwYijC3AmkceNKqWUp13YHg6dWmqmVv4pP7l7c94XI92I0EXVGO0w==",
+      "dev": true
     },
     "node_modules/jest-worker": {
       "version": "27.5.1",
@@ -1309,6 +1337,26 @@
         "webpack": "^5.0.0"
       }
     },
+    "node_modules/typedarray-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-6dOYeZfS3O9RtRD1caom0sMxgK59b27+IwoNy8RDPsmslSGOyU+mpTamlaIW7aNKi90ZQZ9DFaZL3YRoiSCULQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/typescript": {
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
@@ -1531,10 +1579,16 @@
       "dev": true
     },
     "@fermyon/spin-sdk": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@fermyon/spin-sdk/-/spin-sdk-0.4.1.tgz",
-      "integrity": "sha512-EeiHN9p++1y0U2JwBYdU0k0h5qTv6wHxL0F8mTia/DbBsYwUziCHr7VWAGP5+DVmmvLuzC+mEhs9AM+ajVsQJQ==",
-      "dev": true
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@fermyon/spin-sdk/-/spin-sdk-0.5.0.tgz",
+      "integrity": "sha512-LMDEU+Zb+Sl0v/ZlTwKTpZ355wCanqs2jKIwbdnl89Rspllo/GhW/QzBgqRuMP1RidIdBXSorxhhufnmMnxQOQ==",
+      "dev": true,
+      "requires": {
+        "Buffer": "^0.0.0",
+        "fast-text-encoding": "^1.0.6",
+        "itty-router": "^3.0.12",
+        "typedarray-to-buffer": "^4.0.0"
+      }
     },
     "@jridgewell/gen-mapping": {
       "version": "0.3.2",
@@ -1866,6 +1920,12 @@
         "update-browserslist-db": "^1.0.10"
       }
     },
+    "Buffer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/Buffer/-/Buffer-0.0.0.tgz",
+      "integrity": "sha512-+zdncl8lI5TCkARStn9F1BwcuJYofYmD0oEHe5FNfCvGfeDJwf6+dSikCdQN6BMXXmHMhNNUagBN367WST1AIQ==",
+      "dev": true
+    },
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -2028,6 +2088,12 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
+    "fast-text-encoding": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
+      "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==",
+      "dev": true
+    },
     "fastest-levenshtein": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -2136,6 +2202,12 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "dev": true
+    },
+    "itty-router": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-3.0.12.tgz",
+      "integrity": "sha512-s98XTPhle6GGbaFf0kYrOD3Q8gyhnqvOqkwYijC3AmkceNKqWUp13YHg6dWmqmVv4pP7l7c94XI92I0EXVGO0w==",
       "dev": true
     },
     "jest-worker": {
@@ -2499,6 +2571,12 @@
         "micromatch": "^4.0.0",
         "semver": "^7.3.4"
       }
+    },
+    "typedarray-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-6dOYeZfS3O9RtRD1caom0sMxgK59b27+IwoNy8RDPsmslSGOyU+mpTamlaIW7aNKi90ZQZ9DFaZL3YRoiSCULQ==",
+      "dev": true
     },
     "typescript": {
       "version": "4.9.5",

--- a/spin/apps/07-kubernetes/magic-8-ball-ts/package.json
+++ b/spin/apps/07-kubernetes/magic-8-ball-ts/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@fermyon/spin-sdk": "^0.4.1",
+    "@fermyon/spin-sdk": "^0.5.0",
     "ts-loader": "^9.4.1",
     "typescript": "^4.8.4",
     "webpack": "^5.74.0",

--- a/spin/apps/07-kubernetes/magic-8-ball-ts/src/index.ts
+++ b/spin/apps/07-kubernetes/magic-8-ball-ts/src/index.ts
@@ -2,13 +2,13 @@ import { HandleRequest, HttpRequest, HttpResponse } from "@fermyon/spin-sdk"
 
 const encoder = new TextEncoder()
 
-export const handleRequest: HandleRequest = async function(request: HttpRequest): Promise<HttpResponse> {
-    let answerJson = `{\"answer\": \"${answer()}\"}`;
-    return {
-      status: 200,
-        headers: { "Content-Type": "application/json" },
-      body: answerJson
-    }
+export const handleRequest: HandleRequest = async function (request: HttpRequest): Promise<HttpResponse> {
+  let answerJson = `{\"answer\": \"${answer()}\"}`;
+  return {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    body: answerJson
+  }
 }
 
 function answer(): string {


### PR DESCRIPTION
cc @karthik2804 

The setup instructions are:

```
    spin templates install --git https://github.com/fermyon/spin-js-sdk --update &&                         \
```

Which means people will get the latest version, which breaks with 0.4.

This PR bumps the TS version for all examples.