### PR TITLE
Update the devcontainer and small updates for magic-8-ball

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,34 +2,53 @@
 # it avoids downloading any platform-specific binaries, and installs the required
 # tools either through Debian's package manager, or through installation scripts
 # that download the appropriate binaries.
+FROM mcr.microsoft.com/devcontainers/base:jammy
 
-# If the examples in this repository require it, update this Dockerfile to install
-# more language toolchains (such as .NET or TinyGo).
-
-FROM --platform=linux/amd64 ubuntu:22.04
+# provided by docker
+ARG TARGETARCH
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
 
 RUN apt-get update && apt-get install -y \
-    bash                                 \
-    git                                  \
-    curl                                 \
     nodejs                               \
     npm                                  \
-    golang-go                            \
-    build-essential libssl-dev pkg-config\
-    glibc-source                         \
-    ca-certificates                      \
-    tree                                 \
-    wget
+    python3-pip
+
+# Install Go
+ARG GO_VERSION="1.22.1"
+RUN wget -O go.tar.gz "https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" && \
+    tar -C /usr/local -xzf go.tar.gz && \
+    rm go.tar.gz
+ENV PATH="$PATH:/usr/local/go/bin"
+
+# Install TinyGo
+ARG TINYGO_VERSION="0.31.1"
+RUN wget "https://github.com/tinygo-org/tinygo/releases/download/v${TINYGO_VERSION}/tinygo_${TINYGO_VERSION}_${TARGETARCH}.deb" && \
+    dpkg -i "tinygo_${TINYGO_VERSION}_${TARGETARCH}.deb"
+
+# Install Spin
+ARG SPIN_VERSION="v2.3.0"
+RUN mkdir -p /opt/spin && \
+    cd /opt/spin && \
+    curl -fsSL https://developer.fermyon.com/downloads/install.sh | bash -s -- -v $SPIN_VERSION && \
+    ln -s /opt/spin/spin /usr/local/bin/spin
+
+# Set the current user before spin install for plugins/templates
+USER $USERNAME
 
 # Install Rust
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
-ENV PATH="/root/.cargo/bin:${PATH}"
-RUN rustup target add wasm32-wasi
+ENV PATH="$PATH:/home/$USERNAME/.cargo/bin"
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- \
+    -y --target wasm32-wasi
 
-# Install the gopls Go Language Server, see https://github.com/golang/tools/tree/master/gopls
-RUN go install golang.org/x/tools/gopls@latest
-
-# Install Spin and required plugins
-RUN (curl -fsSL https://developer.fermyon.com/downloads/install.sh | bash -s -- -v v1.5.0 && mv spin /usr/local/bin/) &&    \
-    spin templates install --git https://github.com/radu-matei/spin-kv-explorer --update &&                                 \
-    spin templates install --git https://github.com/radu-matei/spin-nextjs --update
+# Install Spin Plugins & Templates
+RUN spin plugins update && \
+    spin plugins install check-for-update -y && \
+    spin plugins install cloud -y && \
+    spin plugins install js2wasm -y && \
+    spin plugins install py2wasm -y && \
+    spin templates install --upgrade --git https://github.com/fermyon/spin && \
+    spin templates install --upgrade --git https://github.com/fermyon/spin-js-sdk && \
+    spin templates install --upgrade --git https://github.com/fermyon/spin-python-sdk && \
+    spin templates install --upgrade --git https://github.com/fermyon/spin-kv-explorer

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,20 +1,15 @@
 {
 	"name": "Fermyon Spin",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "ghcr.io/fermyon/workshops/dev-container:20230920-075415-ge7406ad",
-	// "build": {
-	// 	"dockerfile": "Dockerfile"
-	// },
+	// "image": "ghcr.io/fermyon/workshops/dev-container:20230920-075415-ge7406ad",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	// Most features are built into the Dockerfile for startup time reduction. For more information, see
+	"features": {},
 	"customizations": {
 		"vscode": {
-			"extensions": [
-				"rust-lang.rust-analyzer",
-				"golang.Go",
-				"ms-dotnettools.vscode-dotnet-runtime",
-				"ms-dotnettools.csharp",
-				"alexcvzz.vscode-sqlite",
-				"qwtel.sqlite-viewer"
-			]
+			"extensions": []
 		},
 		// Use 'mounts' to make the cargo cache persistent in a Docker Volume.
 		// "mounts": [
@@ -30,12 +25,12 @@
 			3001,
 			3002,
 			3003
-		]
+		],
 		// Use 'postCreateCommand' to run commands after the container is created.
 		// "postCreateCommand": "rustc --version",
 		// Configure tool-specific properties.
 		// "customizations": {},
 		// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-		// "remoteUser": "root"
+		"remoteUser": "vscode"
 	}
 }

--- a/magic-8-ball/00-setup.md
+++ b/magic-8-ball/00-setup.md
@@ -38,9 +38,8 @@ If you installed Spin using the install script, it also installs the plugins and
 You may also find the following templates helpful for extending beyond the workshop.
 
 ```bash
-# Install a few templates we will use to build applications.
-$ spin templates install --git https://github.com/radu-matei/spin-kv-explorer --update
-$ spin templates install --git https://github.com/radu-matei/spin-nextjs --update
+spin templates install --git https://github.com/fermyon/spin-kv-explorer --update
+spin templates install --git https://github.com/radu-matei/spin-nextjs --update
 ```
 
 Depending on the programming languages you want to use, you will need to configure their toolchains. For example:
@@ -48,7 +47,6 @@ Depending on the programming languages you want to use, you will need to configu
 - [Rust](https://www.rust-lang.org/learn/get-started) (including the Wasm/WASI target: `rustup target install wasm32-wasi`)
 - [Node.js and NPM](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
 - [Go](https://go.dev/doc/install) and [TinyGo](https://tinygo.org/getting-started/install)
-- [.NET](https://dotnet.microsoft.com/en-us/download/dotnet/7.0)
 
 ## Option B: Using a local dev container with VS Code
 

--- a/magic-8-ball/README.md
+++ b/magic-8-ball/README.md
@@ -4,7 +4,7 @@
   - Includes using Serverless AI, and deploying to Kubernetes.
 
 **Last Updated**
-This workshop was last updated for Open Source Summit Bilbao 2023
+This workshop was last updated for SCALE 21x 2024
 
 ## Workshop Modules
 


### PR DESCRIPTION
I updated the devcontainer to include recent versions of spin and supported languages. Once the devcontainer builds through github workflow, I'll update the devcontainer.json file with the correct image tag.